### PR TITLE
46 ingredient register

### DIFF
--- a/cook-service/build.gradle
+++ b/cook-service/build.gradle
@@ -62,6 +62,12 @@ dependencies {
 
     // validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/cook-service/build.gradle
+++ b/cook-service/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
     // FeignClient
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/cook-service/src/main/java/com/sobok/cookservice/common/config/QueryDslConfig.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.sobok.cookservice.common.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/cook-service/src/main/java/com/sobok/cookservice/common/exception/CommonExceptionHandler.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/exception/CommonExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -28,5 +29,16 @@ public class CommonExceptionHandler {
         HttpStatus status = e.status;
         log.error("예외 발생! 메세지 : {}", e.getMessage());
         return new ResponseEntity<>(ApiResponse.fail(status, "엔티티를 찾을 수 없습니다."), status);
+    }
+
+    // 식재료 등록 시 잘못된 request body일 경우
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationErrors(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((m1, m2) -> m1 + ", " + m2)
+                .orElse("입력값이 올바르지 않습니다.");
+
+        return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST, "입력 오류: " + message), HttpStatus.BAD_REQUEST);
     }
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
@@ -37,7 +37,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     List<String> whiteList = List.of(
-            "/actuator/**", "/error", "/ingredient/keyword-search"
+            "/actuator/**", "/ingredient/keyword-search"
     );
 
     @Override
@@ -50,7 +50,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 허용 url 리스트를 순회하면서 지금 들어온 요청 url과 하나라도 일치하면 true 리턴
         boolean isAllowed = whiteList.stream()
-                        .anyMatch(url -> antPathMatcher.match(url, path));
+                .anyMatch(url -> antPathMatcher.match(url, path));
 
         // 허용 path라면 Filter 동작하지 않고 넘기기
         if (isAllowed) {
@@ -62,7 +62,7 @@ public class JwtFilter extends OncePerRequestFilter {
         try {
             // 토큰이 존재하는 지 확인
             String authHeader = request.getHeader("Authorization");
-            if (authHeader == null || authHeader.isEmpty() ) {
+            if (authHeader == null || authHeader.isEmpty()) {
                 log.warn("Authorization 헤더가 비어있습니다.");
                 throw new Exception();
             }
@@ -82,7 +82,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
             // 토큰에서 사용자 정보 추출
             Claims claims = getClaims(token);
-
             // 토큰에서 정보 추출
             long id = Long.parseLong(claims.getSubject());
             Role role = Role.from(claims.get("role", String.class));
@@ -104,6 +103,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     /**
      * claim 꺼내기
+     *
      * @param token
      * @return
      */
@@ -122,6 +122,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     /**
      * 토큰 유효기간 검증
+     *
      * @param token
      * @return
      */
@@ -143,6 +144,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     /**
      * 인증 통과하지 못하면(토큰에 문제가 있다면) 에러 응답 전송
+     *
      * @param response
      * @throws IOException
      */

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
@@ -37,7 +37,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     List<String> whiteList = List.of(
-            "/actuator/**"
+            "/actuator/**", "/error", "/ingredient/keyword-search"
     );
 
     @Override

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
@@ -37,7 +37,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     List<String> whiteList = List.of(
-            "/actuator/**", "/api/ingredient-register"
+            "/actuator/**"
     );
 
     @Override

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 // 허용 URI 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/actuator/**", "/api/ingredient-register"
+                                "/actuator/**", "/error", "/ingredient/keyword-search"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.sobok.cookservice.common.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -11,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@EnableMethodSecurity(prePostEnabled = true)
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -32,7 +34,7 @@ public class SecurityConfig {
                 // 허용 URI 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/actuator/**", "/error", "/ingredient/keyword-search"
+                                "/actuator/**", "/ingredient/keyword-search"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -3,16 +3,17 @@ package com.sobok.cookservice.cook.controller;
 import com.sobok.cookservice.common.dto.ApiResponse;
 import com.sobok.cookservice.common.dto.TokenUserInfo;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
+import com.sobok.cookservice.cook.dto.request.KeywordSearchReqDto;
+import com.sobok.cookservice.cook.entity.Ingredient;
 import com.sobok.cookservice.cook.service.IngredientService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/ingredient")
@@ -23,9 +24,17 @@ public class IngredientController {
     private final IngredientService ingredientService;
 
     @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping("/ingredient-register")
+    @PostMapping("/register")
     public ResponseEntity<Object> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
         ingredientService.ingreCreate(reqDto);
-        return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "재료가 등록되었습니다."));
+        return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "식재료가 등록되었습니다."));
     }
+
+    @GetMapping("/keyword-search")
+    public ResponseEntity<Object> ingreSearch(@RequestBody KeywordSearchReqDto keywordSearchReqDto) {
+        List<Ingredient> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
+        return ResponseEntity.ok().body(ApiResponse.ok(ingredients, "키워드로 검색한 식재료 결과입니다."));
+    }
+
+
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -1,8 +1,16 @@
 package com.sobok.cookservice.cook.controller;
 
+import com.sobok.cookservice.common.dto.ApiResponse;
+import com.sobok.cookservice.common.dto.TokenUserInfo;
+import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import com.sobok.cookservice.cook.service.IngredientService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,4 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class IngredientController {
 
     private final IngredientService ingredientService;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/ingredient-register")
+    public ResponseEntity<Object> ingreRegister(@RequestBody IngreReqDto reqDto) {
+        ingredientService.ingreCreate(reqDto);
+        return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "재료가 등록되었습니다."));
+    }
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -10,8 +10,10 @@ import com.sobok.cookservice.cook.service.IngredientService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +29,7 @@ public class IngredientController {
     /**
      * 관리자 재료 등록
      */
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/register")
     public ResponseEntity<Object> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
         ingredientService.ingreCreate(reqDto);
@@ -40,6 +42,9 @@ public class IngredientController {
     @GetMapping("/keyword-search")
     public ResponseEntity<Object> ingreSearch(@RequestBody KeywordSearchReqDto keywordSearchReqDto) {
         List<IngreResDto> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
+        if (ingredients.isEmpty()) {
+            return ResponseEntity.ok().body(ApiResponse.ok(null, HttpStatus.NO_CONTENT));  // 204
+        }
         return ResponseEntity.ok().body(ApiResponse.ok(ingredients, "키워드로 검색한 식재료 결과입니다."));
     }
 

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -4,6 +4,7 @@ import com.sobok.cookservice.common.dto.ApiResponse;
 import com.sobok.cookservice.common.dto.TokenUserInfo;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import com.sobok.cookservice.cook.dto.request.KeywordSearchReqDto;
+import com.sobok.cookservice.cook.dto.response.IngreResDto;
 import com.sobok.cookservice.cook.entity.Ingredient;
 import com.sobok.cookservice.cook.service.IngredientService;
 import jakarta.validation.Valid;
@@ -23,6 +24,9 @@ public class IngredientController {
 
     private final IngredientService ingredientService;
 
+    /**
+     * 관리자 재료 등록
+     */
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/register")
     public ResponseEntity<Object> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
@@ -30,9 +34,12 @@ public class IngredientController {
         return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "식재료가 등록되었습니다."));
     }
 
+    /**
+     * 통합 재료 검색
+     */
     @GetMapping("/keyword-search")
     public ResponseEntity<Object> ingreSearch(@RequestBody KeywordSearchReqDto keywordSearchReqDto) {
-        List<Ingredient> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
+        List<IngreResDto> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
         return ResponseEntity.ok().body(ApiResponse.ok(ingredients, "키워드로 검색한 식재료 결과입니다."));
     }
 

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -4,11 +4,11 @@ import com.sobok.cookservice.common.dto.ApiResponse;
 import com.sobok.cookservice.common.dto.TokenUserInfo;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import com.sobok.cookservice.cook.service.IngredientService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +24,7 @@ public class IngredientController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/ingredient-register")
-    public ResponseEntity<Object> ingreRegister(@RequestBody IngreReqDto reqDto) {
+    public ResponseEntity<Object> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
         ingredientService.ingreCreate(reqDto);
         return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "재료가 등록되었습니다."));
     }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientFeignController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientFeignController.java
@@ -20,10 +20,6 @@ public class IngredientFeignController {
 
     private final IngredientService ingredientService;
 
-    @PostMapping("/ingredient-register")
-    public ResponseEntity<Object> ingreRegister(@RequestBody IngreReqDto reqDto) {
-        ingredientService.ingreCreate(reqDto);
-        return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "재료가 등록되었습니다."));
-    }
+
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
@@ -1,5 +1,6 @@
 package com.sobok.cookservice.cook.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
@@ -10,9 +11,16 @@ import lombok.*;
 @Builder
 public class IngreReqDto {
 
+    @NotBlank(message = "식재료 이름은 필수입니다.")
     private String ingreName;
+
+    @NotBlank(message = "식재료 가격은 필수입니다.")
     private String price;
+
+    @NotBlank(message = "식재료 원산지는 필수입니다.")
     private String origin;
+
+    @NotBlank(message = "식재료 단위는 필수입니다.")
     private String unit;
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/KeywordSearchReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/KeywordSearchReqDto.java
@@ -1,0 +1,13 @@
+package com.sobok.cookservice.cook.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeywordSearchReqDto {
+    private String keyword;
+}

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/IngreResDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/IngreResDto.java
@@ -1,5 +1,13 @@
 package com.sobok.cookservice.cook.dto.response;
 
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class IngreResDto {
 //    private Long id;
     private String ingreName;

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/IngreResDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/IngreResDto.java
@@ -1,0 +1,10 @@
+package com.sobok.cookservice.cook.dto.response;
+
+public class IngreResDto {
+//    private Long id;
+    private String ingreName;
+    private String price;
+    private String origin;
+    private String unit;
+
+}

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/entity/Ingredient.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/entity/Ingredient.java
@@ -1,16 +1,14 @@
 package com.sobok.cookservice.cook.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
 @Builder
+@ToString
 @Table(name = "ingredient")
 public class Ingredient {
 

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
@@ -1,11 +1,19 @@
 package com.sobok.cookservice.cook.repository;
 
+import com.sobok.cookservice.cook.dto.response.IngreResDto;
 import com.sobok.cookservice.cook.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     Boolean existsByIngreName(String ingreName);
 
+//    List<IngreResDto> keywordSearch(String keyword);
+
+    @Query("SELECT i FROM Ingredient i WHERE i.ingreName LIKE %:keyword% ORDER BY i.ingreName ASC")
+    List<Ingredient> keywordSearch(@Param("keyword") String keyword);
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
@@ -11,9 +11,4 @@ import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     Boolean existsByIngreName(String ingreName);
-
-//    List<IngreResDto> keywordSearch(String keyword);
-
-    @Query("SELECT i FROM Ingredient i WHERE i.ingreName LIKE %:keyword% ORDER BY i.ingreName ASC")
-    List<Ingredient> keywordSearch(@Param("keyword") String keyword);
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
-    Optional<Ingredient> findByIngreName(String ingreName);
+    Boolean existsByIngreName(String ingreName);
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/repository/IngredientRepository.java
@@ -1,13 +1,8 @@
 package com.sobok.cookservice.cook.repository;
 
-import com.sobok.cookservice.cook.dto.response.IngreResDto;
 import com.sobok.cookservice.cook.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     Boolean existsByIngreName(String ingreName);

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
@@ -2,12 +2,16 @@ package com.sobok.cookservice.cook.service;
 
 import com.sobok.cookservice.common.exception.CustomException;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
+import com.sobok.cookservice.cook.dto.request.KeywordSearchReqDto;
+import com.sobok.cookservice.cook.dto.response.IngreResDto;
 import com.sobok.cookservice.cook.entity.Ingredient;
 import com.sobok.cookservice.cook.repository.IngredientRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -35,5 +39,11 @@ public class IngredientService {
 
         ingredientRepository.save(ingredient);
 
+    }
+
+    public List<Ingredient> ingreSearch(KeywordSearchReqDto keywordSearchReqDto) {
+        List<Ingredient> ingreResList = ingredientRepository.keywordSearch(keywordSearchReqDto.getKeyword());
+        log.info("ingreResList: {}", ingreResList.toString());
+        return ingreResList;
     }
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -22,9 +20,9 @@ public class IngredientService {
     public void ingreCreate(IngreReqDto reqDto) {
 
         // 재료 이름으로 db에 있는지 확인
-        Optional<Ingredient> byIngreName = ingredientRepository.findByIngreName(reqDto.getIngreName());
+        Boolean isExist = ingredientRepository.existsByIngreName(reqDto.getIngreName());
 
-        if (byIngreName.isPresent()) {
+        if (isExist) {
             throw new CustomException("이미 등록된 재료입니다.", HttpStatus.BAD_REQUEST);
         }
 

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
@@ -33,6 +33,7 @@ public class IngredientService {
      */
     public void ingreCreate(IngreReqDto reqDto) {
 
+        log.info("컨트롤러 통과");
         // 재료 이름으로 db에 있는지 확인
         Boolean isExist = ingredientRepository.existsByIngreName(reqDto.getIngreName());
 

--- a/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
@@ -38,8 +38,7 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
     private static final List<String> whiteList = List.of(
             "/actuator",
             "/sms/send", "/sms/verify", "/auth/recover/**", "/auth/login", "/auth/reissue",
-            "/auth/user-signup","/auth/rider-signup","/auth/shop-signup", 
-             "/api/ingredient-register",
+            "/auth/user-signup","/auth/rider-signup","/auth/shop-signup",
             "/auth/findLoginId", "/auth/verification", "/auth/reset-password", "/user/findByPhoneNumber",
             "/auth/temp-token"
     );

--- a/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
@@ -40,7 +40,7 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
             "/sms/send", "/sms/verify", "/auth/recover/**", "/auth/login", "/auth/reissue",
             "/auth/user-signup","/auth/rider-signup","/auth/shop-signup",
             "/auth/findLoginId", "/auth/verification", "/auth/reset-password", "/user/findByPhoneNumber",
-            "/auth/temp-token"
+            "/auth/temp-token", "/ingredient/keyword-search"
     );
 
     /**


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> 식재료 등록(관리자), 식재료 검색(통합)

---

## 🔧 작업 내용 상세

- 관리자용 식재료 등록 기능
- 키워드로 식재료 검색 기능을 queryDSL을 활용하여 구현
- 식재료 등록 api 잘못된 request body일때 예외 설정 추가
- 식재료 검색 결과가 없을 때 204코드 반환하도록 수정

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- cook-service, gateway-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

close #46 

---