### PR TITLE
55 ingredient update

### DIFF
--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/IngredientController.java
@@ -2,6 +2,7 @@ package com.sobok.cookservice.cook.controller;
 
 import com.sobok.cookservice.common.dto.ApiResponse;
 import com.sobok.cookservice.common.dto.TokenUserInfo;
+import com.sobok.cookservice.cook.dto.request.IngreEditReqDto;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import com.sobok.cookservice.cook.dto.request.KeywordSearchReqDto;
 import com.sobok.cookservice.cook.dto.response.IngreResDto;
@@ -10,6 +11,7 @@ import com.sobok.cookservice.cook.service.IngredientService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.Fetch;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,7 +33,7 @@ public class IngredientController {
      */
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/register")
-    public ResponseEntity<Object> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
+    public ResponseEntity<?> ingreRegister(@Valid @RequestBody IngreReqDto reqDto) {
         ingredientService.ingreCreate(reqDto);
         return ResponseEntity.ok().body(ApiResponse.ok(reqDto.getIngreName(), "식재료가 등록되었습니다."));
     }
@@ -40,7 +42,7 @@ public class IngredientController {
      * 통합 재료 검색
      */
     @GetMapping("/keyword-search")
-    public ResponseEntity<Object> ingreSearch(@RequestBody KeywordSearchReqDto keywordSearchReqDto) {
+    public ResponseEntity<?> ingreSearch(@RequestBody KeywordSearchReqDto keywordSearchReqDto) {
         List<IngreResDto> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
         if (ingredients.isEmpty()) {
             return ResponseEntity.ok().body(ApiResponse.ok(null, HttpStatus.NO_CONTENT));  // 204
@@ -48,5 +50,28 @@ public class IngredientController {
         return ResponseEntity.ok().body(ApiResponse.ok(ingredients, "키워드로 검색한 식재료 결과입니다."));
     }
 
+    /**
+     * 식재료 전체 조회 (관리자)
+     */
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all-search")
+    public ResponseEntity<?> allSearch() {
+        KeywordSearchReqDto keywordSearchReqDto = KeywordSearchReqDto.builder().keyword("").build();
+        List<IngreResDto> ingredients = ingredientService.ingreSearch(keywordSearchReqDto);
+        if (ingredients.isEmpty()) {
+            return ResponseEntity.ok().body(ApiResponse.ok(null, HttpStatus.NO_CONTENT));  // 204
+        }
+        return ResponseEntity.ok().body(ApiResponse.ok(ingredients, "전체 식재료 결과입니다."));
+    }
+
+    /**
+     * 식재료 정보 수정 (관리자)
+     */
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PatchMapping("/edit")
+    public ResponseEntity<?> ingreEdit(@Valid @RequestBody IngreEditReqDto newReqDto) {
+        ingredientService.ingreEdit(newReqDto);
+        return ResponseEntity.ok().body(ApiResponse.ok(newReqDto.getId(), "해당 식재료 정보가 수정되었습니다."));
+    }
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreEditReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreEditReqDto.java
@@ -1,5 +1,6 @@
-package com.sobok.cookservice.cook.dto.response;
+package com.sobok.cookservice.cook.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -8,11 +9,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class IngreResDto {
+public class IngreEditReqDto {
+    @NotNull(message = "식재료 Id는 필수입니다.")
     private Long id;
     private String ingreName;
     private String price;
     private String origin;
     private String unit;
-
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
@@ -11,6 +11,8 @@ import lombok.*;
 @Builder
 public class IngreReqDto {
 
+    private Long id;
+
     @NotBlank(message = "식재료 이름은 필수입니다.")
     private String ingreName;
 

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/entity/Ingredient.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/entity/Ingredient.java
@@ -1,7 +1,10 @@
 package com.sobok.cookservice.cook.entity;
 
+import com.sobok.cookservice.cook.dto.request.IngreEditReqDto;
+import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.util.StringUtils;
 
 @Getter
 @AllArgsConstructor
@@ -27,5 +30,13 @@ public class Ingredient {
 
     @Column(nullable = false)
     private String unit;
+
+    public void update(IngreEditReqDto dto) {
+        if (StringUtils.hasText(dto.getIngreName())) this.ingreName = dto.getIngreName();
+        if (StringUtils.hasText(dto.getPrice())) this.price = dto.getPrice();
+        if (StringUtils.hasText(dto.getOrigin())) this.origin = dto.getOrigin();
+        if (StringUtils.hasText(dto.getUnit())) this.unit = dto.getUnit();
+    }
+
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/service/IngredientService.java
@@ -3,6 +3,7 @@ package com.sobok.cookservice.cook.service;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sobok.cookservice.common.exception.CustomException;
+import com.sobok.cookservice.cook.dto.request.IngreEditReqDto;
 import com.sobok.cookservice.cook.dto.request.IngreReqDto;
 import com.sobok.cookservice.cook.dto.request.KeywordSearchReqDto;
 import com.sobok.cookservice.cook.dto.response.IngreResDto;
@@ -68,6 +69,7 @@ public class IngredientService {
         return factory
                 .select(Projections.fields(
                         IngreResDto.class,
+                        ingredient.id,
                         ingredient.ingreName,
                         ingredient.price,
                         ingredient.origin,
@@ -77,5 +79,18 @@ public class IngredientService {
                 .where(builder)
                 .orderBy(ingredient.ingreName.asc())
                 .fetch();
+    }
+
+    /**
+     * 식재료 정보 수정 (관리자)
+     */
+    public void ingreEdit(IngreEditReqDto newReqDto) {
+        log.info("newReqDto: {}", newReqDto);
+        Ingredient ingredient = ingredientRepository.findById(newReqDto.getId()).orElseThrow(
+                () -> new CustomException("해당 식재료가 존재하지 않습니다.", HttpStatus.BAD_REQUEST)
+        );
+        ingredient.update(newReqDto);
+        ingredientRepository.save(ingredient);
+        log.info("정보 변경 완료");
     }
 }

--- a/shop-service/src/main/java/com/sobok/shopservice/shop/controller/ShopFeignController.java
+++ b/shop-service/src/main/java/com/sobok/shopservice/shop/controller/ShopFeignController.java
@@ -49,6 +49,7 @@ public class ShopFeignController {
     @GetMapping("/check-shopAddress")
     public ResponseEntity<Boolean> checkShopAddress(@RequestParam String shopAddress) {
         return ResponseEntity.ok(shopRepository.existsByRoadFull((shopAddress)));
+    }
 
 
     @GetMapping("/shop-info")


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> 식재료 전체 조회, 식재료 수정 기능 구현

---

## 🔧 작업 내용 상세

- 식재료 검색시 응답 dto에 id 추가
- 관리자용 식재료 조회 기능
- 관리자용 식재료 정보 수정 기능

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- cook-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- #55  

---