### PR TITLE
feat : 요리 조회 3인방 API 구현

### DIFF
--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/JwtFilter.java
@@ -38,6 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     List<String> whiteList = List.of(
             "/actuator/**", "/ingredient/keyword-search"
+            , "/cook/get-cook", "/cook/get-cook-category", "/cook/search-cook"
     );
 
     @Override

--- a/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/common/security/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/actuator/**", "/ingredient/keyword-search"
+                                , "/cook/get-cook", "/cook/get-cook-category", "/cook/search-cook"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/controller/CookController.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/controller/CookController.java
@@ -3,12 +3,15 @@ package com.sobok.cookservice.cook.controller;
 import com.sobok.cookservice.common.dto.ApiResponse;
 import com.sobok.cookservice.cook.dto.request.CookCreateReqDto;
 import com.sobok.cookservice.cook.dto.response.CookCreateResDto;
+import com.sobok.cookservice.cook.dto.response.CookResDto;
 import com.sobok.cookservice.cook.service.CookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/cook")
@@ -25,5 +28,33 @@ public class CookController {
         CookCreateResDto resDto = cookService.createCook(dto);
         return ResponseEntity.ok().body(ApiResponse.ok(resDto, "요리 등록 성공"));
     }
+
+    /**
+     * 요리 전체 조회
+     */
+    @GetMapping("/get-cook")
+    public ResponseEntity<?> getCook(@RequestParam Long pageNo, @RequestParam Long numOfRows) {
+        List<CookResDto> resDto = cookService.getCook(pageNo, numOfRows);
+        return ResponseEntity.ok().body(ApiResponse.ok(resDto, "페이징으로 요청한 모든 요리가 정상적으로 조회되었습니다."));
+    }
+
+    /**
+     * 요리 전체 조회
+     */
+    @GetMapping("/search-cook")
+    public ResponseEntity<?> getCook(@RequestParam String keyword, @RequestParam Long pageNo, @RequestParam Long numOfRows) {
+        List<CookResDto> resDto = cookService.searchCook(keyword, pageNo, numOfRows);
+        return ResponseEntity.ok().body(ApiResponse.ok(resDto, "페이징으로 요청한 키워드 검색 요리가 정상적으로 조회되었습니다."));
+    }
+
+    /**
+     * 요리 카테고리 조회
+     */
+    @GetMapping("/get-cook-category")
+    public ResponseEntity<?> getCookCategory(@RequestParam String category, @RequestParam Long pageNo, @RequestParam Long numOfRows) {
+        List<CookResDto> resDto = cookService.getCookByCategory(category, pageNo, numOfRows);
+        return ResponseEntity.ok().body(ApiResponse.ok(resDto, "페이징으로 요청한 카테고리 검색이 정상적으로 조회되었습니다."));
+    }
+
 
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/CookResDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/response/CookResDto.java
@@ -1,0 +1,21 @@
+package com.sobok.cookservice.cook.dto.response;
+
+import com.sobok.cookservice.common.enums.CookCategory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CookResDto {
+    private Long id;
+    private String name;
+    private String allergy;
+    private String recipe;
+    private CookCategory category;
+    private String thumbnail;
+}

--- a/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
@@ -43,6 +43,7 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
             "/ingredient/keyword-search",
             "/auth/temp-token", "/auth/check-id", "/auth/check-nickname", "/auth/check-email","/auth/check-permission",
             "/auth/check-shopName", "/auth/check-shopAddress"
+            , "/cook/get-cook", "/cook/get-cook-category", "/cook/search-cook"
     );
 
     /**


### PR DESCRIPTION
close #61

## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> 요리 조회, 요리 검색, 요리 카테고리 조회 API 구현

---

## 🔧 작업 내용 상세

- 요리 전체 조회, 요리 검색, 요리 카테고리 조회 페이징 처리
- 검색 함수 재활용
- 토큰 없이 접근 허용

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- cook, gateway

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- #61 

---