### PR TITLE
fix: auth-service 검증 api 각 서비스로 분리

### DIFF
--- a/delivery-service/src/main/java/com/sobok/deliveryservice/common/security/JwtFilter.java
+++ b/delivery-service/src/main/java/com/sobok/deliveryservice/common/security/JwtFilter.java
@@ -37,7 +37,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     List<String> whiteList = List.of(
-            "/actuator/**","/delivery/signup", "/auth/check-permission"
+            "/actuator/**","/delivery/signup", "/auth/check-permission","/delivery/check-permission"
     );
 
     @Override

--- a/delivery-service/src/main/java/com/sobok/deliveryservice/common/security/SecurityConfig.java
+++ b/delivery-service/src/main/java/com/sobok/deliveryservice/common/security/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                 // 허용 URI 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/actuator/**","/delivery/signup", "/auth/check-permission"
+                                "/actuator/**","/delivery/signup", "/auth/check-permission",
+                                "/delivery/check-permission"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/delivery-service/src/main/java/com/sobok/deliveryservice/delivery/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/sobok/deliveryservice/delivery/controller/DeliveryController.java
@@ -1,6 +1,7 @@
 package com.sobok.deliveryservice.delivery.controller;
 
 
+import com.sobok.deliveryservice.common.dto.ApiResponse;
 import com.sobok.deliveryservice.delivery.dto.request.RiderReqDto;
 import com.sobok.deliveryservice.delivery.dto.response.RiderResDto;
 import com.sobok.deliveryservice.delivery.service.DeliveryService;
@@ -8,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -26,5 +24,14 @@ public class DeliveryController {
         log.info("rider signup 요청 들어옴");
         RiderResDto response = deliveryService.riderCreate(dto);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 라이더 면허 번호 중복 확인
+     */
+    @GetMapping("/check-permission")
+    public ResponseEntity<?> checkPermission(@RequestParam String permission) {
+        deliveryService.checkPermission(permission);
+        return ResponseEntity.ok(ApiResponse.ok(null, "사용 가능한 면허번호 입니다."));
     }
 }

--- a/delivery-service/src/main/java/com/sobok/deliveryservice/delivery/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/sobok/deliveryservice/delivery/service/DeliveryService.java
@@ -147,6 +147,13 @@ public class DeliveryService {
                 .build();
     }
 
-
+    /**
+     * 라이더 면허번호 중복 체크
+     */
+    public void checkPermission(String permission) {
+        if (riderRepository.existsByPermissionNumber(permission)) {
+            throw new CustomException("사용할 수 없는 면허번호 입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
 
 }

--- a/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
+++ b/gateway-service/src/main/java/com/sobok/gatewayservice/common/filter/AuthorizationFilter.java
@@ -45,7 +45,8 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
             "/auth/check-shopName", "/auth/check-shopAddress"
             , "/cook/get-cook", "/cook/get-cook-category", "/cook/search-cook"
             , "/api/confirm", "/api/kakao-login",
-            "/auth/kakao-user-signup"
+            "/auth/kakao-user-signup","/user/check-nickname","/user/check-email","/delivery/check-permission",
+            "/shop/check-shopName", "/shop/check-shopAddress"
     );
 
     /**

--- a/shop-service/src/main/java/com/sobok/shopservice/common/security/JwtFilter.java
+++ b/shop-service/src/main/java/com/sobok/shopservice/common/security/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     List<String> whiteList = List.of(
             "/actuator/**", "/auth/check-shopName",
-            "/auth/check-shopAddress"
+            "/auth/check-shopAddress", "/shop/check-shopName", "/shop/check-shopAddress"
     );
 
     @Override

--- a/shop-service/src/main/java/com/sobok/shopservice/common/security/SecurityConfig.java
+++ b/shop-service/src/main/java/com/sobok/shopservice/common/security/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                 // 허용 URI 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/actuator/**", "/auth/check-shopName", "/auth/check-shopAddress"
+                                "/actuator/**", "/auth/check-shopName", "/auth/check-shopAddress",
+                                "/shop/check-shopName", "/shop/check-shopAddress"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/shop-service/src/main/java/com/sobok/shopservice/shop/controller/ShopController.java
+++ b/shop-service/src/main/java/com/sobok/shopservice/shop/controller/ShopController.java
@@ -8,10 +8,7 @@ import com.sobok.shopservice.shop.service.ShopService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/shop")
@@ -19,7 +16,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ShopController {
 
+    private final ShopService shopService;
+    /**
+     * 가게 이름 중복 확인
+     */
+    @GetMapping("/check-shopName")
+    public ResponseEntity<?> checkShopName(@RequestParam String shopName) {
+        shopService.checkShopName(shopName);
+        return ResponseEntity.ok(ApiResponse.ok(null, "사용 가능한 지점명 입니다."));
+    }
 
-
+    /**
+     * 가게 주소 중복 확인
+     */
+    @GetMapping("/check-shopAddress")
+    public ResponseEntity<?> checkShopAddress(@RequestParam String shopAddress) {
+        shopService.checkShopAddress(shopAddress);
+        return ResponseEntity.ok(ApiResponse.ok(null, "사용 가능한 주소 입니다."));
+    }
 
 }

--- a/shop-service/src/main/java/com/sobok/shopservice/shop/service/ShopService.java
+++ b/shop-service/src/main/java/com/sobok/shopservice/shop/service/ShopService.java
@@ -140,4 +140,22 @@ public class ShopService {
                 .shopPhone(shop.getPhone())
                 .build();
     }
+
+    /**
+     * 가게 이름 중복 체크
+     */
+    public void checkShopName(String shopName) {
+        if (shopRepository.existsByShopName(shopName)) {
+            throw new CustomException("이미 등록된 지점명 입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * 가게 주소 중복 체크
+     */
+    public void checkShopAddress(String shopAddress) {
+        if (shopRepository.existsByRoadFull(shopAddress)) {
+            throw new CustomException("중복된 가게 주소 입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/user-service/src/main/java/com/sobok/userservice/common/security/JwtFilter.java
+++ b/user-service/src/main/java/com/sobok/userservice/common/security/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     List<String> whiteList = List.of(
             "/actuator/**", "/user/findByPhoneNumber", "/auth/findLoginId", "/auth/check-nickname",
-            "/auth/check-email", "/error"
+            "/auth/check-email", "/error","/user/check-nickname","/user/check-email"
     );
 
     @Override

--- a/user-service/src/main/java/com/sobok/userservice/common/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/sobok/userservice/common/security/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/actuator/**", "/user/findByPhoneNumber", "/auth/findLoginId",
-                                "/auth/check-nickname", "/auth/check-email", "/error"
+                                "/auth/check-nickname", "/auth/check-email", "/error",
+                                "/user/check-nickname","/user/check-email"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/user-service/src/main/java/com/sobok/userservice/user/controller/UserController.java
+++ b/user-service/src/main/java/com/sobok/userservice/user/controller/UserController.java
@@ -111,5 +111,22 @@ public class UserController {
 
     // TODO : 사진 추가 변경 가능해야 함.
 
+    /**
+     * user 닉네임 중복 확인
+     */
+    @GetMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        userService.checkNickname(nickname);
+        return ResponseEntity.ok(ApiResponse.ok(null, "사용 가능한 닉네임입니다."));
+    }
+
+    /**
+     * email 중복 확인
+     */
+    @GetMapping("/check-email")
+    public ResponseEntity<?> checkEmail(@RequestParam String email) {
+        userService.checkEmail(email);
+        return ResponseEntity.ok(ApiResponse.ok(null, "사용 가능한 이메일입니다."));
+    }
 
 }

--- a/user-service/src/main/java/com/sobok/userservice/user/service/UserService.java
+++ b/user-service/src/main/java/com/sobok/userservice/user/service/UserService.java
@@ -401,4 +401,22 @@ public class UserService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 주소에 연결된 유저를 찾을 수 없습니다."));
     }
 
+    /**
+     * nickname 중복 체크
+     */
+    public void checkNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CustomException("이미 사용 중인 닉네임입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * email 중복 체크
+     */
+    public void checkEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException("이미 사용 중인 이메일입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
 }


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> auth-service 검증 api 각 서비스로 분리

---

## 🔧 작업 내용 상세

- auth-service 검증 api 각 서비스로 분리
- 
-

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- gateway-service
- delivery-service
- user-service
- shop-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- 

---