### PR TITLE
refactor: paymentId 기반 다중 요리 게시글 등록 기능 구현

### DIFF
--- a/post-service/src/main/java/com/sobok/postservice/post/dto/request/PostRegisterReqDto.java
+++ b/post-service/src/main/java/com/sobok/postservice/post/dto/request/PostRegisterReqDto.java
@@ -9,9 +9,18 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class PostRegisterReqDto {
-    private Long cookId;
-    private String title;
-    private List<PostImageDto> images;
-    private String content;
     private Long paymentId;
+    private List<PostUnitDto> posts;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PostUnitDto {
+        private Long cookId;
+        private String title;
+        private String content;
+        private List<PostImageDto> images;
+    }
+
 }

--- a/post-service/src/main/java/com/sobok/postservice/post/dto/response/PostRegisterResDto.java
+++ b/post-service/src/main/java/com/sobok/postservice/post/dto/response/PostRegisterResDto.java
@@ -2,12 +2,24 @@ package com.sobok.postservice.post.dto.response;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostRegisterResDto {
-    private Long postId;
-    private String cookName;
+    private List<PostInfo> posts;
+
+    @Getter
+    @Builder
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostInfo {
+        private Long postId;
+        private String cookName;
+    }
+
 }


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> paymentId 기반 다중 요리 게시글 등록 기능 구현

---

## 🔧 작업 내용 상세

- paymentId 기반 다중 요리 게시글 등록 기능 구현
-
-

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- post-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- #160 

---