### PR TITLE
fix: 회원가입시 상세주소 null값 못오게 수정

### DIFF
--- a/auth-service/src/main/java/com/sobok/authservice/auth/dto/request/AuthUserReqDto.java
+++ b/auth-service/src/main/java/com/sobok/authservice/auth/dto/request/AuthUserReqDto.java
@@ -34,6 +34,8 @@ public class AuthUserReqDto {
     )
     private String email;
     private String photo;
+
+    @NotBlank(message = "주소는 필수 입니다.")
     private String roadFull;
     private String addrDetail;
     private String inputCode;


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> 회원가입시 상세주소 null값 못오게 수정

---

## 🔧 작업 내용 상세

- 회원가입시 상세주소 null값 못오게 수정
-
-

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- auth-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- #181 

---