### PR TITLE
fix: 식재료, 요리등록 가격 단위 음수값 입력 안되게 수정

### DIFF
--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/CookCreateReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/CookCreateReqDto.java
@@ -2,6 +2,7 @@ package com.sobok.cookservice.cook.dto.request;
 
 import com.sobok.cookservice.common.enums.CookCategory;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -44,6 +45,7 @@ public class CookCreateReqDto {
         private Long ingredientId; // 식재료 id
 
         @NotNull(message = "단위 수량은 필수입니다.")
+        @Min(value = 1, message = "단위 수량은 1 이상이어야 합니다.")
         private Integer unitQuantity; // 식재료 단위
     }
 }

--- a/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
+++ b/cook-service/src/main/java/com/sobok/cookservice/cook/dto/request/IngreReqDto.java
@@ -1,5 +1,6 @@
 package com.sobok.cookservice.cook.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -18,12 +19,14 @@ public class IngreReqDto {
     private String ingreName;
 
     @NotNull
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private Integer price;
 
     @NotBlank(message = "식재료 원산지는 필수입니다.")
     private String origin;
 
     @NotNull
+    @Min(value = 1, message = "단위는 1 이상이어야 합니다.")
     private Integer unit;
 
 }


### PR DESCRIPTION
## 📝 PR 요약
(어떤 작업을 했는지 한 줄 요약해주세요)

> 식재료, 요리등록 가격 단위 음수값 입력 안되게 수정

---

## 🔧 작업 내용 상세

- 식재료, 요리등록 가격 단위 음수값 입력 안되게 수정
-
-

### 변경한 모듈/서비스
(예: user-service, gateway, config-server 등)

- cook-service

---

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

- 

---